### PR TITLE
Revert "Make trailing slash optional in webhook URL"

### DIFF
--- a/sfdoc/publish/tests/test_urls.py
+++ b/sfdoc/publish/tests/test_urls.py
@@ -13,16 +13,9 @@ class TestPublishURLs(TestCase):
             'publish:webhook',
         )
 
-    def test_webhook_resolve_2(self):
-        """/publish/webhook/ should resolve to publish:webhook."""
-        self.assertEqual(
-            resolve('/publish/webhook').view_name,
-            'publish:webhook',
-        )
-
     def test_webhook_reverse(self):
         """publish:webhook should reverse to /publish/webhook/."""
         self.assertEqual(
             reverse('publish:webhook'),
-            '/publish/webhook',
+            '/publish/webhook/',
         )

--- a/sfdoc/publish/urls.py
+++ b/sfdoc/publish/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
         name='review',
     ),
     url(
-        regex=r'^webhook(/)?$',
+        regex=r'^webhook/$',
         view=views.webhook,
         name='webhook',
     ),


### PR DESCRIPTION
Reverts SalesforceFoundation/sfdoc#184